### PR TITLE
[BUG] set a longer idle time to capture key events.

### DIFF
--- a/test/Graphics/test_graphics_view.cpp
+++ b/test/Graphics/test_graphics_view.cpp
@@ -121,16 +121,24 @@ TEST_F(TestGraphicsViewEvents, test_send_pressed_key_event)
   QSignalSpy spy(test_window_, SIGNAL(sendEvent(Event)));
   EXPECT_TRUE(spy.isValid());
 
-  // Ask the testing window to wait for 10 ms.
+#ifdef _WIN32
+  int wait_ms = 100;
+  int key_press_time_ms = 10;
+#else
+  int wait_ms = 10;
+  int key_press_time_ms = 1;
+#endif
+
+  // Ask the testing window to wait for an event.
   QMetaObject::invokeMethod(test_window_, "waitForEvent",
-    Qt::AutoConnection, Q_ARG(int, 10));
+                            Qt::AutoConnection, Q_ARG(int, wait_ms));
 
-  // Schedule a key press event 1 ms later.
+  // Schedule a key press event later.
   QKeyEvent qt_event(QEvent::KeyPress, key_, Qt::NoModifier);
-  event_scheduler_.schedule_event(&qt_event, 1);
+  event_scheduler_.schedule_event(&qt_event, key_press_time_ms);
 
-  // The spy waits for the event during 100 ms.
-  EXPECT_TRUE(spy.wait(100));
+  // The spy waits for the event.
+  EXPECT_TRUE(spy.wait(2*wait_ms));
 
   // Check that the spy received one key press event.
   EXPECT_EQ(spy.count(), 1);

--- a/test/Graphics/test_opengl_window.cpp
+++ b/test/Graphics/test_opengl_window.cpp
@@ -132,16 +132,24 @@ TEST_F(TestOpenGLWindowEvents, test_send_pressed_key_event)
   QSignalSpy spy(test_window_, SIGNAL(sendEvent(Event)));
   EXPECT_TRUE(spy.isValid());
 
-  // Ask the testing window to wait for 10 ms.
+#ifdef _WIN32
+  int wait_ms = 100;
+  int key_press_time_ms = 10;
+#else
+  int wait_ms = 10;
+  int key_press_time_ms = 1;
+#endif
+
+  // Ask the testing window to wait.
   QMetaObject::invokeMethod(test_window_, "waitForEvent",
-                            Qt::AutoConnection, Q_ARG(int, 10));
+                            Qt::AutoConnection, Q_ARG(int, wait_ms));
 
-  // Schedule a key press event 30 ms later.
+  // Schedule a key press event.
   QKeyEvent qt_event(QEvent::KeyPress, key_, Qt::NoModifier);
-  event_scheduler_.schedule_event(&qt_event, 30);
+  event_scheduler_.schedule_event(&qt_event, key_press_time_ms);
 
-  // The spy waits for the event during 100 ms.
-  EXPECT_TRUE(spy.wait(100));
+  // The spy waits for the events.
+  EXPECT_TRUE(spy.wait(2*wait_ms));
 
   // Check that the spy received one key press event.
   EXPECT_EQ(spy.count(), 1);

--- a/test/Graphics/test_opengl_window.cpp
+++ b/test/Graphics/test_opengl_window.cpp
@@ -136,9 +136,9 @@ TEST_F(TestOpenGLWindowEvents, test_send_pressed_key_event)
   QMetaObject::invokeMethod(test_window_, "waitForEvent",
                             Qt::AutoConnection, Q_ARG(int, 10));
 
-  // Schedule a key press event 1 ms later.
+  // Schedule a key press event 30 ms later.
   QKeyEvent qt_event(QEvent::KeyPress, key_, Qt::NoModifier);
-  event_scheduler_.schedule_event(&qt_event, 1);
+  event_scheduler_.schedule_event(&qt_event, 30);
 
   // The spy waits for the event during 100 ms.
   EXPECT_TRUE(spy.wait(100));
@@ -165,9 +165,9 @@ TEST_F(TestOpenGLWindowEvents, test_send_released_key_event)
   QMetaObject::invokeMethod(test_window_, "waitForEvent",
                             Qt::AutoConnection, Q_ARG(int, 10));
 
-  // Schedule a key press event 1 ms later.
+  // Schedule a key press event 30 ms later.
   QKeyEvent qt_event(QEvent::KeyRelease, key_, Qt::NoModifier);
-  event_scheduler_.schedule_event(&qt_event, 1);
+  event_scheduler_.schedule_event(&qt_event, 30);
 
   // Check that the spy received one key press event.
   EXPECT_TRUE(spy.wait(100));

--- a/test/Graphics/test_opengl_window.cpp
+++ b/test/Graphics/test_opengl_window.cpp
@@ -161,16 +161,24 @@ TEST_F(TestOpenGLWindowEvents, test_send_released_key_event)
   QSignalSpy spy(test_window_, SIGNAL(sendEvent(Event)));
   EXPECT_TRUE(spy.isValid());
 
+#ifdef _WIN32
+  int wait_ms = 100;
+  int key_press_time_ms = 10;
+#else
+  int wait_ms = 10;
+  int key_press_time_ms = 1;
+#endif
+
   // Ask the testing window to wait for 10 ms.
   QMetaObject::invokeMethod(test_window_, "waitForEvent",
-                            Qt::AutoConnection, Q_ARG(int, 10));
+                            Qt::AutoConnection, Q_ARG(int, wait_ms));
 
   // Schedule a key press event 30 ms later.
   QKeyEvent qt_event(QEvent::KeyRelease, key_, Qt::NoModifier);
-  event_scheduler_.schedule_event(&qt_event, 30);
+  event_scheduler_.schedule_event(&qt_event, key_press_time_ms);
 
   // Check that the spy received one key press event.
-  EXPECT_TRUE(spy.wait(100));
+  EXPECT_TRUE(spy.wait(2*wait_ms));
   EXPECT_EQ(spy.count(), 1);
 
   // Check the details of the key release event.

--- a/test/Graphics/test_window_management.cpp
+++ b/test/Graphics/test_window_management.cpp
@@ -43,7 +43,7 @@ TEST(TestWindow, test_open_and_close_window)
 
   // Check that the widget gets destroyed when we close the window.
   close_window(window);
-  while (!scroll_area.isNull());
+  millisleep(10);
   EXPECT_TRUE(scroll_area.isNull());
   EXPECT_TRUE(window.isNull());
 }
@@ -60,7 +60,7 @@ TEST(TestWindow, test_open_and_close_gl_window)
   EXPECT_EQ(window->pos(), QPoint(10, 10));
 
   close_window(window);
-  while (!window.isNull());
+  millisleep(10);
   EXPECT_TRUE(window.isNull());
 }
 
@@ -76,7 +76,7 @@ TEST(TestWindow, test_open_and_close_graphics_view)
   EXPECT_EQ(window->pos(), QPoint(10, 10));
 
   close_window(window);
-  while (!window.isNull());
+  millisleep(10);
   EXPECT_TRUE(window.isNull());
 }
 


### PR DESCRIPTION
This seems to be specific to Windows platform after upgrading to Qt 5.4.