### PR TITLE
[MAINT] By default don't build tests and samples.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ before_script:
 script:
   - mkdir build
   - cd build
-  - cmake -DCMAKE_BUILD_TYPE=Debug ..
-  - make -j 4
+  - cmake -DCMAKE_BUILD_TYPE=Debug -DDO_BUILD_TESTS=ON -DDO_BUILD_SAMPLES=ON ..
+  - make -j4
   - ctest --output-on-failure
 
 after_success:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,12 @@ option(DO_USE_FROM_SOURCE
        "Use DO++ libraries from source"             ON)
 option(DO_USE_STATIC_LIBS
        "Use DO++ static libraries"                  OFF)
-option(DO_BUILD_UNIT_TESTS
-       "Build unit tests for DO++ libraries"        ON)
+option(DO_BUILD_TESTS
+       "Build unit tests for DO++ libraries"        OFF)
 option(DO_USE_VLD
        "Enable Visual Leak Detector for unit tests" OFF)
-option(DO_BUILD_SAMPLE_PROGRAMS
-       "Build sample programs using DO++ libraries" ON)
+option(DO_BUILD_SAMPLES
+       "Build sample programs using DO++ libraries" OFF)
 option(DO_BUILD_SHARED_LIBS
        "Build shared libraries for DO++ libraries"  OFF)
 
@@ -47,13 +47,13 @@ include(DOInstall)
 add_subdirectory(third-party)
 
 # Setup unit test projects
-if (DO_BUILD_UNIT_TESTS)
+if (DO_BUILD_TESTS)
   enable_testing()
   add_subdirectory(test)
 endif ()
 
 # Setup unit test projects
-if (DO_BUILD_SAMPLE_PROGRAMS)
+if (DO_BUILD_SAMPLES)
   add_subdirectory(examples)
 endif ()
 

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -8,7 +8,7 @@ set (CMAKE_C_FLAGS "")
 set (CMAKE_CXX_FLAGS "")
 
 
-if (DO_BUILD_UNIT_TESTS)
+if (DO_BUILD_TESTS)
   message(STATUS "  - Google Test")
   add_subdirectory(gtest)
   set_property(TARGET gtest PROPERTY FOLDER ${THIRDPARTY_FOLDER_NAME})


### PR DESCRIPTION
We want to minimize compile time when we integrate DO-CV as a third-party library.